### PR TITLE
Context updates regardless of when the command is installed

### DIFF
--- a/src/arc/command/command.py
+++ b/src/arc/command/command.py
@@ -96,7 +96,7 @@ class Command(utils.Helpful):
     def install_command(self, command: "Command"):
         """Installs a command object as a subcommand
         of the current object"""
-        command.context = self.context | command.context
+        command.propagate_context(self.context)
         self.subcommands[command.name] = command
 
         if "help" not in self.subcommands and self.name != "help":
@@ -206,6 +206,11 @@ class Command(utils.Helpful):
         If it isn't valid, raise a `ValidationError`"""
 
     # Utils
+
+    def propagate_context(self, new_context):
+        self.context = new_context | self.context
+        for command in self.subcommands.values():
+            command.propagate_context(self.context)
 
     def cleanup(self):
         for arg in self.args.values():

--- a/src/arc/parser/data_types.py
+++ b/src/arc/parser/data_types.py
@@ -11,11 +11,11 @@ class TokenizerMode(Enum):
     BODY = symbol("body")
 
 
-COMMAND = symbol("command")
-FLAG = symbol("flags")
-ARGUMENT = symbol("arguments")
-POS_ARGUMENT = symbol("positional argument")
-KEY_ARGUMENT = symbol("key argument")
+COMMAND: symbol = symbol("command")
+FLAG: symbol = symbol("flags")
+ARGUMENT: symbol = symbol("arguments")
+POS_ARGUMENT: symbol = symbol("positional argument")
+KEY_ARGUMENT: symbol = symbol("key argument")
 
 
 @dataclass

--- a/src/arc/parser/parser.py
+++ b/src/arc/parser/parser.py
@@ -8,7 +8,6 @@ from arc import utils
 from .data_types import (
     COMMAND,
     FLAG,
-    ARGUMENT,
     POS_ARGUMENT,
     KEY_ARGUMENT,
     TokenizerMode,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -41,3 +41,14 @@ class TestContext(TestCase):
 
         run(self.mock, "other_context_name")
         other_context_name.function.assert_called_with(foo=Context({"test": 1}))
+
+    def test_propagate(self):
+        test_namespace = mock_command("test_namespace")
+
+        @test_namespace.subcommand(context={"test2": 2})
+        def test(ctx: Context):
+            ...
+
+        self.mock.install_command(test_namespace)
+        run(self.mock, "test_namespace:test")
+        test.function.assert_called_with(ctx=Context({"test": 1, "test2": 2}))


### PR DESCRIPTION
added `Command#propagate_context` for context updates

closes #53 