### PR TITLE
3.10 fix

### DIFF
--- a/src/arc/command/helpers.py
+++ b/src/arc/command/helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import inspect
-from typing import Dict, Any, TYPE_CHECKING, Callable
+from typing import Dict, Any, TYPE_CHECKING, Callable, get_type_hints
 import functools
 import textwrap
 
@@ -25,8 +25,18 @@ class CommandMixin:
                 raise CommandError(f"No value for required option '{option.name}'")
 
 
+class ParamProxy:
+    def __init__(self, param: inspect.Parameter, annotation: type):
+        self.param = param
+        self.annotation = annotation
+
+    def __getattr__(self, name):
+        return getattr(self.param, name)
+
+
 class ArgBuilder:
     def __init__(self, function):
+        self.__annotations = get_type_hints(function)
         self.__sig = inspect.signature(function)
         self.__length = len(self.__sig.parameters.values())
         self.__args: Dict[str, Option] = {}
@@ -43,8 +53,9 @@ class ArgBuilder:
 
     def __iter__(self):
         for param in self.__sig.parameters.values():
-            yield param
-            self.add_arg(param)
+            proxy = ParamProxy(param, self.__annotations.get(param.name, str))
+            yield proxy
+            self.add_arg(proxy)
 
     @property
     def args(self):
@@ -54,7 +65,7 @@ class ArgBuilder:
     def hidden_args(self):
         return self.__hidden_args
 
-    def add_arg(self, param: inspect.Parameter):
+    def add_arg(self, param: ParamProxy):
         if Context in param.annotation.mro():
             self.__hidden_args["context"] = Option(
                 param.name, param.annotation, NO_DEFAULT

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -18,4 +18,6 @@ def mock_command(
     name: str = "mock", cls: Type[Command] = KeywordCommand, func=lambda: ..., **kwargs
 ) -> MockedCommand:
     mocked = type(f"Mocked{cls.__name__}", (MockedCommand, cls), {})
-    return mocked(name, create_autospec(func), **kwargs)
+    mocked_func = create_autospec(func)
+    mocked_func.__annotations__ = func.__annotations__
+    return mocked(name, mocked_func, **kwargs)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from arc import CLI, namespace, run
+from arc import run
 from arc.command import Context
 
 from .mock import mock_command


### PR DESCRIPTION
3.10 will "stringify" all type annotations, but we can use get_type_hints to resolve the strings